### PR TITLE
refactor: Align ProjActivity API with nested routing pattern

### DIFF
--- a/LMS.Presentation/Controllers/ProjActivitiesController.cs
+++ b/LMS.Presentation/Controllers/ProjActivitiesController.cs
@@ -1,11 +1,15 @@
 ﻿using LMS.Shared.DTOs.EntitiesDtos.ProjActivity;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Service.Contracts;
 
 namespace LMS.Presentation.Controllers
 {
     [ApiController]
-    [Route("api/activities")]
+    [Route("api/modules/{moduleId:int}/activities")]
+    [Authorize]
+    [Tags("Activities")]
     public class ProjActivitiesController : ControllerBase
     {
         private readonly IServiceManager _serviceManager;
@@ -16,45 +20,46 @@ namespace LMS.Presentation.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<ProjActivityDto>>> GetActivities()
-        {
-            var activities = await _serviceManager.ProjActivityService.GetAllActivitiesAsync();
-            return Ok(activities);
-        }
-
-        [HttpGet("{id}")]
-        public async Task<ActionResult<ProjActivityDto>> GetActivity(int id)
-        {
-            var activity = await _serviceManager.ProjActivityService.GetActivityByIdAsync(id);
-            if (activity == null) return NotFound();
-            return Ok(activity);
-        }
-
-
-        [HttpGet("module/{moduleId}")]
-        public async Task<ActionResult<IEnumerable<ProjActivityDto>>> GetActivitiesByModule(int moduleId)
+        public async Task<ActionResult<IEnumerable<ProjActivityDto>>> GetActivities(int moduleId)
         {
             var activities = await _serviceManager.ProjActivityService.GetActivitiesByModuleIdAsync(moduleId);
             return Ok(activities);
         }
 
-        [HttpPost]
-        public async Task<ActionResult<ProjActivityDto>> CreateActivity(CreateProjActivityDto dto)
+        [HttpGet("{id}")]
+        public async Task<ActionResult<ProjActivityDto>> GetActivity(int moduleId, int id)
         {
-            var createdActivity = await _serviceManager.ProjActivityService.CreateActivityAsync(dto);
-            return CreatedAtAction(nameof(GetActivity), new { id = createdActivity.Id }, createdActivity);
+            var activity = await _serviceManager.ProjActivityService.GetActivityByIdAsync(id);
+            if (activity == null || activity.ModuleId != moduleId)
+                return NotFound();
+            return Ok(activity);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<ProjActivityDto>> CreateActivity(int moduleId, CreateProjActivityDto dto)
+        {
+            var createdActivity = await _serviceManager.ProjActivityService.CreateActivityAsync(moduleId, dto);
+            return CreatedAtAction(nameof(GetActivity), new { moduleId, id = createdActivity.Id }, createdActivity);
         }
 
         [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateActivity(int id, UpdateProjActivityDto dto)
+        public async Task<IActionResult> UpdateActivity(int moduleId, int id, UpdateProjActivityDto dto)
         {
+            var activity = await _serviceManager.ProjActivityService.GetActivityByIdAsync(id);
+            if (activity == null || activity.ModuleId != moduleId)
+                return NotFound();
+
             await _serviceManager.ProjActivityService.UpdateActivityAsync(id, dto);
             return NoContent();
         }
 
         [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteActivity(int id)
+        public async Task<IActionResult> DeleteActivity(int moduleId, int id)
         {
+            var activity = await _serviceManager.ProjActivityService.GetActivityByIdAsync(id);
+            if (activity == null || activity.ModuleId != moduleId)
+                return NotFound();
+
             await _serviceManager.ProjActivityService.DeleteActivityAsync(id);
             return NoContent();
         }

--- a/LMS.Services/ProjActivityService.cs
+++ b/LMS.Services/ProjActivityService.cs
@@ -38,9 +38,10 @@ namespace LMS.Services
             return _mapper.Map<IEnumerable<ProjActivityDto>>(activities);
         }
 
-        public async Task<ProjActivityDto> CreateActivityAsync(CreateProjActivityDto dto)
+        public async Task<ProjActivityDto> CreateActivityAsync(int moduleId, CreateProjActivityDto dto)
         {
             var activity = _mapper.Map<ProjActivity>(dto);
+            activity.ModuleId = moduleId;
             _unitOfWork.ProjActivityRepository.Create(activity);
             await _unitOfWork.CompleteAsync();
             return _mapper.Map<ProjActivityDto>(activity);

--- a/LMS.Shared/DTOs/EntitiesDtos/ProjActivity/CreateProjActivityDto.cs
+++ b/LMS.Shared/DTOs/EntitiesDtos/ProjActivity/CreateProjActivityDto.cs
@@ -12,6 +12,5 @@ namespace LMS.Shared.DTOs.EntitiesDtos.ProjActivity
         public string? Description { get; set; }
         public DateTime Starts { get; set; }
         public DateTime Ends { get; set; }
-        public int ModuleId { get; set; }
     }
 }

--- a/Service.Contracts/IProjActivityService.cs
+++ b/Service.Contracts/IProjActivityService.cs
@@ -7,7 +7,7 @@ namespace Service.Contracts
         Task<IEnumerable<ProjActivityDto>> GetAllActivitiesAsync(bool trackChanges = false);
         Task<ProjActivityDto?> GetActivityByIdAsync(int id, bool trackChanges = false);
         Task<IEnumerable<ProjActivityDto>> GetActivitiesByModuleIdAsync(int moduleId, bool trackChanges = false);
-        Task<ProjActivityDto> CreateActivityAsync(CreateProjActivityDto dto);
+        Task<ProjActivityDto> CreateActivityAsync(int moduleId, CreateProjActivityDto dto);
         Task UpdateActivityAsync(int id, UpdateProjActivityDto dto);
         Task DeleteActivityAsync(int id);
     }


### PR DESCRIPTION
- Update route from 'api/activities' to 'api/modules/{moduleId}/activities'
- Remove ModuleId from CreateProjActivityDto (passed via URL instead)
- Update service to accept moduleId parameter in CreateActivityAsync
- Add [Authorize] attribute for consistency with other controllers
- Add moduleId validation in all endpoints
- Add [Tags("Activities")] for cleaner Swagger documentation

This aligns ProjActivitiesController with the same pattern used by ModuleController and follows RESTful nested resource conventions.