### PR TITLE
feat: auto-remove notifications when student deletes uploaded file

### DIFF
--- a/LMS.Services/NotificationService.cs
+++ b/LMS.Services/NotificationService.cs
@@ -180,4 +180,22 @@ public class NotificationService : INotificationService
         await AddNotificationAsync(message);
     }
 
+    public async Task DeleteNotificationByDocumentIdAsync(int documentId)
+    {
+        var notifications = await GetAllNotificationsAsync();
+        var notificationsToRemove = notifications.Where(n =>
+            n.Message.Contains($"|{documentId}")).ToList();
+
+        foreach (var notification in notificationsToRemove)
+        {
+            notifications.Remove(notification);
+        }
+
+        if (notificationsToRemove.Any())
+        {
+            await SaveNotificationsAsync(notifications);
+        }
+    }
+
+
 }

--- a/LMS.Services/ProjDocumentService.cs
+++ b/LMS.Services/ProjDocumentService.cs
@@ -128,10 +128,14 @@ namespace LMS.Services
             try { await _storage.DeleteAsync(doc.FileName, ct); }
             catch (Exception ex) { _logger.LogWarning(ex, "Failed to delete blob for document {Id}", id); }
 
+            // Remove related notifications
+            await _notificationService.DeleteNotificationByDocumentIdAsync(id);
+
             _uow.ProjDocumentRepository.Delete(doc);
             await _uow.CompleteAsync();
             return true;
         }
+
 
 
         public async Task<bool> SetStatusAsync(int documentId, DocumentStatus status, string changedByUserId, CancellationToken ct = default)

--- a/Service.Contracts/INotificationService.cs
+++ b/Service.Contracts/INotificationService.cs
@@ -13,6 +13,8 @@ public interface INotificationService
     Task<ContactMessageDto?> DecryptContactMessageDirectAsync(string encryptedData);
     Task DeleteNotificationAsync(string notificationId);
     Task NotifyFileUploadAsync(string studentName, string courseName, string moduleName, string activityTitle, string fileName, int documentId);
+    Task DeleteNotificationByDocumentIdAsync(int documentId);
+
 
 
 


### PR DESCRIPTION
When a student deletes an uploaded file, the corresponding notification is now automatically removed from teachers' notification lists to keep the system synchronized.

Changes:
- Added DeleteNotificationByDocumentIdAsync() to INotificationService
- Implemented notification cleanup logic in NotificationService that finds and removes notifications containing the document ID
- Modified ProjDocumentService.DeleteAsync() to trigger notification removal before deleting the document
- Notifications are identified by document ID suffix (|{documentId})

Files modified:
- Service.Contracts/INotificationService.cs
- LMS.Services/NotificationService.cs
- LMS.Services/ProjDocumentService.cs